### PR TITLE
Added shortcut key (Alt-X) for search box

### DIFF
--- a/src/frontend/js/Components/Editor/EditorGrid.js
+++ b/src/frontend/js/Components/Editor/EditorGrid.js
@@ -103,6 +103,7 @@ Ext.define('PartKeepr.EditorGrid', {
 		});
 		
 		this.searchField = Ext.create("Ext.ux.form.SearchField",{
+				id: 'thesearchfield',
 				store: this.store
 			});
 		

--- a/src/frontend/js/PartKeepr.js
+++ b/src/frontend/js/PartKeepr.js
@@ -38,8 +38,20 @@ Ext.application({
         	}
     	}
     	
-    	
-    	
+		new Ext.util.KeyMap(Ext.get(document), {
+			key: 'x',
+			ctrl: false,
+			alt: true,
+			fn: function(e) {
+				var searchBox = Ext.getCmp('thesearchfield');
+				if (Ext.get(document).activeElement != searchBox) {
+					searchBox.focus('',10);
+				}
+				searchBox.setValue('');
+			},
+			stopEvent: true
+		});
+
         Ext.fly(document.body).on('contextmenu', this.onContextMenu, this);
     },
     onContextMenu: function (e, target) {
@@ -598,4 +610,4 @@ PartKeepr.serializeRecords = function (records) {
 	}
 	
 	return finalData;
-}; 
+};


### PR DESCRIPTION
Demonstration code intended for use with a barcode scanner.  Adds a shortcut key for the search box.  Scanner prefixes the scanned code with a key combination (set to Alt-X) and postfixes with a CRLF - this activates the search box and triggers a search.
Code could be better implemented and requires a user preference for the key combination.  A separate search box used only for part numbers may be preferred.
