### PR TITLE
Added SKU entry to part distributor

### DIFF
--- a/src/backend/PartKeepr/Part/PartDistributor.php
+++ b/src/backend/PartKeepr/Part/PartDistributor.php
@@ -47,6 +47,13 @@ class PartDistributor extends BaseEntity implements Serializable, Deserializable
 	private $price;
 	
 	/**
+	 * The distributor's SKU (stock keeping unit) for the part.  Used with barcodes.
+	 * @Column(type="string",nullable=true)
+	 * @var string
+	 */
+	private $sku;
+
+	/**
 	 * Cretes a new part->distributor link. Initializes the packaging unit with a quantity of "1".
 	 * 
 	 * @param Part $part The part
@@ -152,6 +159,22 @@ class PartDistributor extends BaseEntity implements Serializable, Deserializable
 	}
 	
 	/**
+	 * Sets the SKU (stock keeping unit)
+	 * @param string $sku The SKU
+	 */
+	public function setSKU ($sku) {
+		$this->sku = $sku;
+	}
+
+	/**
+	 * Returns the SKU (stock keeping unit)
+	 * @return string The SKU
+	 */
+	public function getSKU () {
+		return $this->sku;
+	}
+
+	/**
 	 * (non-PHPdoc)
 	 * @see PartKeepr\Util.Serializable::serialize()
 	 */
@@ -164,7 +187,8 @@ class PartDistributor extends BaseEntity implements Serializable, Deserializable
 			"part_id" => $this->getPart()->getId(),
 			"part_name" => $this->getPart()->getName(),
 			"packagingUnit" => $this->getPackagingUnit(),
-			"price" => $this->getPrice());
+			"price" => $this->getPrice(),
+			"sku" => $this->getSKU());
 	}
 	
 	/**
@@ -186,6 +210,9 @@ class PartDistributor extends BaseEntity implements Serializable, Deserializable
 					break;
 				case "price":
 					$this->setPrice($value);
+					break;
+				case "sku":
+					$this->setSKU($value);
 					break;
 			}
 		}

--- a/src/frontend/js/Components/Part/Editor/PartDistributorGrid.js
+++ b/src/frontend/js/Components/Part/Editor/PartDistributorGrid.js
@@ -52,7 +52,7 @@ Ext.define('PartKeepr.PartDistributorGrid', {
 		}, {
 			header : i18n("Order Number"),
 			dataIndex : 'orderNumber',
-			flex : 0.3,
+			flex : 0.2,
 			editor : {
 				xtype : 'textfield',
 				allowBlank : true
@@ -77,6 +77,14 @@ Ext.define('PartKeepr.PartDistributorGrid', {
 			editor : {
 				xtype : 'CurrencyField',
 				allowBlank : false
+			}
+		}, {
+			header : i18n("SKU"),
+			dataIndex : 'sku',
+			flex : 0.1,
+			editor : {
+				xtype : 'textfield',
+				allowBlank : true
 			}
 		} ];
 

--- a/src/frontend/js/Models/PartDistributor.js
+++ b/src/frontend/js/Models/PartDistributor.js
@@ -1,14 +1,15 @@
 Ext.define("PartKeepr.PartDistributor", {
 	extend: "Ext.data.Model",
 	fields: [
-	         {	id: 'id', name: 'id',			type: 'int' },
-	         {	name: 'part_id',			type: 'int' },
-	         {	name: 'part_name',			type: 'string' },
-	         {	name: 'distributor_id',			type: 'int' },
-	         {	name: 'distributor_name',			type: 'string' },
-	         {	name: 'price',			type: 'float' },
-	         { name: 'orderNumber', type: 'string' },
-	         { name: 'packagingUnit', type: 'int'}
+	         { id: 'id', name: 'id',     type: 'int' },
+	         { name: 'part_id',          type: 'int' },
+	         { name: 'part_name',        type: 'string' },
+	         { name: 'distributor_id',   type: 'int' },
+	         { name: 'distributor_name', type: 'string' },
+	         { name: 'price',            type: 'float' },
+	         { name: 'orderNumber',      type: 'string' },
+	         { name: 'packagingUnit',    type: 'int'},
+	         { name: 'sku',              type: 'string' }
 	         ],
 	belongsTo: { type: 'belongsTo', model: 'PartKeepr.Part', primaryKey: 'id', foreignKey: 'part_id'},
 	belongsTo: { type: 'belongsTo', model: 'PartKeepr.Distributor', primaryKey: 'id', foreignKey: 'distributor_id'},


### PR DESCRIPTION
Provides an entry for the distributor's SKU (stock keeping unit).  The distributor's SKU is often different from their order number.  Adding this entry will allow searching via the distributor's SKU, typically by scanning the product barcode, once the search code is expanded to include searching by distributor data.

This change requires a 'sku' column or type varchar(255) to be added to the 'PartDistributor' database table.
