### PR TITLE
Fix for part parameters grid view

### DIFF
--- a/src/frontend/js/Components/Part/Editor/PartParameterGrid.js
+++ b/src/frontend/js/Components/Part/Editor/PartParameterGrid.js
@@ -63,7 +63,8 @@ Ext.define('PartKeepr.PartParameterGrid', {
 		                	renderer: function (val,p,rec) {
 		                		if (!Ext.isObject(val)) { return ""; }
 		                		
-		                		var foundRec = PartKeepr.getApplication().getUnitStore().findRecord("id", rec.get("unit_id"));
+								var unitStore = PartKeepr.getApplication().getUnitStore();
+								var foundRec = unitStore.findRecord("id", rec.get("unit_id"), 0, false, false, true);
 		                		
 		                		if (foundRec) {
 		                			return val.value + " "+val.symbol + foundRec.get("symbol");


### PR DESCRIPTION
There's an issue in the part parameters view.
When you select Meters or Grams as parameter Unit, the value is prefixed with "C" and "Ah" instead of "m" and "g".
Enabling "exactMatch" parameter in the findRecord call fixes it.
Bug is present in the 0.1.9 release and the web demo.
