### PR TITLE
Allow setting a comment on stock removal

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartDisplay.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartDisplay.js
@@ -221,10 +221,11 @@ Ext.define('PartKeepr.PartDisplay', {
     /**
      * Callback after the "delete stock" dialog is complete.
      */
-    deletePartHandler: function (quantity)
+    deletePartHandler: function (quantity, unused_price, comment)
     {
         this.record.callPutAction("removeStock", {
             quantity: quantity,
+            comment: comment,
         }, null, true);
     },
     /**

--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartStockWindow.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartStockWindow.js
@@ -178,8 +178,7 @@ Ext.define('PartKeepr.PartStockWindow', {
 		this.setTitle(this.removePartText);
 		this.priceField.hide();
 		this.priceCheckbox.hide();
-		this.commentField.hide();
-		this.setHeight(105);
+		this.setHeight(132);
 		this.okButton.setIconCls("web-icon brick_delete");
 		this.show();
 	}

--- a/src/PartKeepr/PartBundle/Action/RemoveStockAction.php
+++ b/src/PartKeepr/PartBundle/Action/RemoveStockAction.php
@@ -65,8 +65,12 @@ class RemoveStockAction
         $user = $this->userService->getUser();
 
         $stock = new StockEntry(0 - intval($quantity), $user);
-        $part->addStockEntry($stock);
 
+        if ($request->request->has("comment") && $request->request->get("comment") !== null) {
+            $stock->setComment($request->request->get("comment"));
+        }
+
+        $part->addStockEntry($stock);
         $this->registry->getManager()->persist($stock);
         $this->registry->getManager()->flush();
 


### PR DESCRIPTION
Comments were already added when removing stock through a project, and
comments on stock removals were already displayed, so this is just a
trivial change that adds a comment box to the remove stock window and
makes sure it is handled.