### PR TITLE
Exclude hidden directories from the requisite check

### DIFF
--- a/app/PartKeeprRequirements.php
+++ b/app/PartKeeprRequirements.php
@@ -149,6 +149,8 @@ class PartKeeprRequirements extends SymfonyRequirements
                     closedir($folder);
                     throw new \Exception($dir."/".$file." is not writable.");
                 } else {
+                    // Skip hidden directories
+                    if ((is_dir($dir."/".$file)) && ($file[0]=='.')) continue;
                     if (is_dir($dir."/".$file)) {
                         if (!$this->isWritableRecursive($dir."/".$file)) {
                             closedir($folder);

--- a/src/PartKeepr/UploadedFileBundle/Services/UploadedFileService.php
+++ b/src/PartKeepr/UploadedFileBundle/Services/UploadedFileService.php
@@ -57,7 +57,8 @@ class UploadedFileService extends ContainerAware
 
     public function replaceFromData(UploadedFile $file, $data, $filename)
     {
-        $tempName = tempnam("/tmp", "PARTKEEPR");
+        $tmpdir = ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir();
+        $tempName = tempnam($tmpdir, "PARTKEEPR");
 
         file_put_contents($tempName, $data);
 


### PR DESCRIPTION
Using the git version will pull most of the dependencies from git. The git client creates object stores using 0444 permissions. This will cause the req. check to fail on check: isWriteableRecursive.

This patch excludes all hidden directories from the check.