### PR TITLE
[Bugfix]: Item prices does not work #500

### DIFF
--- a/src/PartKeepr/PartBundle/Entity/Part.php
+++ b/src/PartKeepr/PartBundle/Entity/Part.php
@@ -823,24 +823,40 @@ class Part extends BaseEntity
     {
         $sum = 0;
         $price = 0;
+		
+		$totalPartStockPrice = 0;
+        $lastPosEntryQuant = 0;
+        $lastPosEntryPrice = 0;
 
         foreach ($this->getStockLevels() as $stockLevel) {
-
-            if ($stockLevel->getStockLevel() < 0) {
-                $this->setRemovals(true);
-            } else {
-                $price += $stockLevel->getPrice() * $stockLevel->getStockLevel();
-            }
-            $sum += $stockLevel->getStockLevel();
-        }
-
-        if ($sum > 0) {
-            $this->setAveragePrice($price / $sum);
-        } else {
-            $this->setAveragePrice(0);
-        }
+			
+			$sum += $stockLevel->getStockLevel();
+			
+			if ($stockLevel->getStockLevel() > 0) {
+				$lastPosEntryQuant = $stockLevel->getStockLevel();
+				$lastPosEntryPrice = $stockLevel->getPrice();
+				$totalPartStockPrice += $lastPosEntryPrice * $lastPosEntryQuant;
+				$price = $totalPartStockPrice / $sum;
+			}
+			else {
+				if  ($sum < 0) {
+					$price = 0;
+					$sum = 0;
+				}
+				else
+					if ($sum < $lastPosEntryQuant){
+						$totalPartStockPrice = $sum * $lastPosEntryPrice;
+						$price = $totalPartStockPrice / $sum;
+					}
+					else {
+						$totalPartStockPrice += $stockLevel->getStockLevel() * $price;
+						$price = $totalPartStockPrice / $sum;
+					}
+			}
+		}
 
         $this->setStockLevel($sum);
+		$this->setAveragePrice($price);
 
         if ($sum < $this->getMinStockLevel()) {
             $this->setLowStock(true);

--- a/src/PartKeepr/PartBundle/Entity/Part.php
+++ b/src/PartKeepr/PartBundle/Entity/Part.php
@@ -841,7 +841,7 @@ class Part extends BaseEntity
 			else {
 				if  ($sum < 0) {
 					$price = 0;
-					$sum = 0;
+					//$sum = 0;
 				}
 				else
 					if ($sum < $lastPosEntryQuant){

--- a/src/PartKeepr/PartBundle/Entity/Part.php
+++ b/src/PartKeepr/PartBundle/Entity/Part.php
@@ -824,39 +824,40 @@ class Part extends BaseEntity
         $sum = 0;
         $price = 0;
 		
-		$totalPartStockPrice = 0;
+        $totalPartStockPrice = 0;
         $lastPosEntryQuant = 0;
         $lastPosEntryPrice = 0;
 
         foreach ($this->getStockLevels() as $stockLevel) {
-			
-			$sum += $stockLevel->getStockLevel();
-			
-			if ($stockLevel->getStockLevel() > 0) {
-				$lastPosEntryQuant = $stockLevel->getStockLevel();
-				$lastPosEntryPrice = $stockLevel->getPrice();
-				$totalPartStockPrice += $lastPosEntryPrice * $lastPosEntryQuant;
-				$price = $totalPartStockPrice / $sum;
+            
+            $sum += $stockLevel->getStockLevel();
+            
+            if ($stockLevel->getStockLevel() > 0) {
+
+                $lastPosEntryQuant = $stockLevel->getStockLevel();
+                $lastPosEntryPrice = $stockLevel->getPrice();
+                $totalPartStockPrice += $lastPosEntryPrice * $lastPosEntryQuant;
+                $price = $totalPartStockPrice / $sum;
 			}
 			else {
-				if  ($sum < 0) {
-					$price = 0;
-					//$sum = 0;
+			    if ($sum < 0) {
+			        $price = 0;
 				}
-				else
-					if ($sum < $lastPosEntryQuant){
-						$totalPartStockPrice = $sum * $lastPosEntryPrice;
-						$price = $totalPartStockPrice / $sum;
+				else {
+				    if ($sum < $lastPosEntryQuant){
+				        $totalPartStockPrice = $sum * $lastPosEntryPrice;
+				        $price = $totalPartStockPrice / $sum;
 					}
 					else {
-						$totalPartStockPrice += $stockLevel->getStockLevel() * $price;
-						$price = $totalPartStockPrice / $sum;
+					    $totalPartStockPrice += $stockLevel->getStockLevel() * $price;
+					    $price = $totalPartStockPrice / $sum;
 					}
+				}
 			}
 		}
 
         $this->setStockLevel($sum);
-		$this->setAveragePrice($price);
+        $this->setAveragePrice($price);
 
         if ($sum < $this->getMinStockLevel()) {
             $this->setLowStock(true);


### PR DESCRIPTION
My idea is to use the strategy below for updating the average price. Then you get a quite good approximation of a FIFO approach of stock use.
Basically: 
- positive stock entry  -> update average price (computed as a (sum of added stock * individual price)/ total number of items).
- negative stock entry:
 - if  negative total, just set everything on zero (avg price, ~~total items~~)
 - if positive total:
   - smaller than the last positive stock entry use the price of the last positive stock entry as avg price. 
    - higher than the last positive stock just update the avg price using the same strategy as for a positive stock entry.