### PR TITLE
Bugfix for issue #569 Delete all user preferences prior deleting the user

### DIFF
--- a/src/PartKeepr/AuthBundle/Action/DeleteUserAction.php
+++ b/src/PartKeepr/AuthBundle/Action/DeleteUserAction.php
@@ -6,6 +6,7 @@ use Dunglas\ApiBundle\Exception\RuntimeException;
 use Dunglas\ApiBundle\Model\DataProviderInterface;
 use PartKeepr\AuthBundle\Entity\User;
 use PartKeepr\AuthBundle\Exceptions\UserProtectedException;
+use PartKeepr\AuthBundle\Services\UserPreferenceService;
 use PartKeepr\AuthBundle\Services\UserService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -27,16 +28,25 @@ class DeleteUserAction
      */
     private $userService;
 
-    public function __construct(DataProviderInterface $dataProvider, UserService $userService)
-    {
+    /**
+     * @var UserPreferenceService
+     */
+    private $userPreferenceService;
+
+    public function __construct(
+        DataProviderInterface $dataProvider,
+        UserService $userService,
+        UserPreferenceService $userPreferenceService
+    ) {
         $this->dataProvider = $dataProvider;
         $this->userService = $userService;
+        $this->userPreferenceService = $userPreferenceService;
     }
 
     /**
      * Returns an item to delete.
      *
-     * @param Request    $request
+     * @param Request $request
      * @param string|int $id
      *
      * @return mixed
@@ -59,6 +69,7 @@ class DeleteUserAction
         }
 
         $this->userService->deleteFOSUser($item);
+        $this->userPreferenceService->deletePreferences($item);
 
 
         return $item;

--- a/src/PartKeepr/AuthBundle/Resources/config/actions.xml
+++ b/src/PartKeepr/AuthBundle/Resources/config/actions.xml
@@ -34,6 +34,7 @@
         <service id="partkeepr.user.delete" class="PartKeepr\AuthBundle\Action\DeleteUserAction">
             <argument type="service" id="api.data_provider"/>
             <argument type="service" id="partkeepr.userservice"/>
+            <argument type="service" id="partkeepr.user_preference_service"/>
         </service>
         <service id="partkeepr.auth.login" class="PartKeepr\AuthBundle\Action\LoginAction">
             <argument type="service" id="partkeepr.userservice"/>

--- a/src/PartKeepr/AuthBundle/Services/UserPreferenceService.php
+++ b/src/PartKeepr/AuthBundle/Services/UserPreferenceService.php
@@ -132,4 +132,19 @@ class UserPreferenceService
         $query->execute();
     }
 
+    /**
+     * Removes all preferences for specific user. This is usually used when removing the user.
+     *
+     * @param \PartKeepr\AuthBundle\Entity\User $user The user to delete the preference for
+     */
+    public function deletePreferences(User $user)
+    {
+        $dql = "DELETE FROM PartKeepr\AuthBundle\Entity\UserPreference up WHERE up.user = :user";
+
+        $query = $this->entityManager->createQuery($dql);
+        $query->setParameter("user", $user);
+
+        $query->execute();
+    }
+
 }


### PR DESCRIPTION
`ON DELETE CASCADE` is not usable in this case as we're using a composite key for `UserPreference`, which may not be linked to the `User` object due to `DunglasApiBundle` limitations.