### PR TITLE
PartKeepr: Option to display and filter part id

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/Editor/PartEditor.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/Editor/PartEditor.js
@@ -178,7 +178,9 @@ Ext.define('PartKeepr.PartEditor', {
                         renderer: function (value)
                         {
                             var values = value.split("/");
-                            return values[values.length - 1];
+                            var idstr = values[values.length - 1];
+                            var idint = parseInt(idstr);
+                            return idstr + " (#"+idint.toString(36)+")";
                         }
                     }
                 ]

--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartDisplay.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartDisplay.js
@@ -49,7 +49,9 @@ Ext.define('PartKeepr.PartDisplay', {
             renderer: function (value)
             {
                 var values = value.split("/");
-                return values[values.length - 1];
+                var idstr = values[values.length - 1];
+                var idint = parseInt(idstr);
+                return idstr + " (#"+idint.toString(36)+")";
             }
         }
     },

--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartFilterPanel.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartFilterPanel.js
@@ -52,6 +52,7 @@ Ext.define('PartKeepr.PartFilterPanel', {
     statusFilter: null,
     conditionFilter: null,
     internalPartNumberFilter: null,
+    internalIdFilter: null,
     commentFilter: null,
 
     /**
@@ -98,7 +99,8 @@ Ext.define('PartKeepr.PartFilterPanel', {
                 this.statusFilter,
                 this.conditionFilter,
                 this.internalPartNumberFilter,
-                this.commentFilter
+                this.commentFilter,
+                this.internalIdFilter
             ]
         };
 
@@ -187,6 +189,7 @@ Ext.define('PartKeepr.PartFilterPanel', {
         this.conditionFilter.setValue("");
         this.internalPartNumberFilter.setValue("");
         this.commentFilter.setValue("");
+        this.internalIdFilter.setValue("");
 
         this.onApply();
     },
@@ -444,6 +447,11 @@ Ext.define('PartKeepr.PartFilterPanel', {
             fieldLabel: i18n("Internal Part Number"),
             anchor: '100%'
         });
+        
+        this.internalIdFilter = Ext.create("Ext.form.field.Text", {
+            fieldLabel: i18n("Internal Id"),
+            anchor: '100%'
+        });
 
         this.commentFilter = Ext.create("Ext.form.field.Text", {
             fieldLabel: i18n("Comment"),
@@ -617,6 +625,22 @@ Ext.define('PartKeepr.PartFilterPanel', {
                 value: "%" + this.commentFilter.getValue() + "%"
             }));
         }
+        
+        if (this.internalIdFilter.getValue() !== "") {
+        	var idstr = this.internalIdFilter.getValue();
+        	if (idstr.substring(0,1) == "#") {
+        		idstr = idstr.substring(1);
+        		var idint = parseInt(idstr,36);
+        	} else {
+        		var idint = parseInt(idstr,10);
+        	}
+            filters.push(Ext.create("Ext.util.Filter", {
+                property: 'id',
+                operator: "=",
+                value: idint
+            }));
+        }
+        
         return filters;
     }
 });

--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartsGrid.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartsGrid.js
@@ -297,7 +297,6 @@ Ext.define('PartKeepr.PartsGrid', {
             }, {
                 header: i18n("Internal ID"),
                 dataIndex: 'id',
-                //renderer: Ext.util.Format.htmlEncode,
                 renderer: this.internalIdRenderer,
                 hidden: true
             }

--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartsGrid.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartsGrid.js
@@ -294,6 +294,12 @@ Ext.define('PartKeepr.PartsGrid', {
                 header: i18n("Create Date"),
                 dataIndex: 'createDate',
                 hidden: true
+            }, {
+                header: i18n("Internal ID"),
+                dataIndex: 'id',
+                //renderer: Ext.util.Format.htmlEncode,
+                renderer: this.internalIdRenderer,
+                hidden: true
             }
 
         ];
@@ -364,6 +370,17 @@ Ext.define('PartKeepr.PartsGrid', {
         if (rec.get("needsReview") === true) {
             ret += '<span class="web-icon flag_orange"' + '" title="' + i18n("Needs review") + '"></span>';
         }
+
+        return ret;
+    },
+    internalIdRenderer: function (val, q, rec)
+    {
+        var ret = "";
+        
+        var values = rec.id.split("/");
+        var idstr = values[values.length - 1];
+        var idint = parseInt(idstr);
+        ret = idstr + " (#"+idint.toString(36)+")";
 
         return ret;
     },


### PR DESCRIPTION
Currently PartKeepr assigns an internal ID to each part, but there is no way to filter for that ID or display it as a column. 
It would be great if that ID could be used to clearly communicate a part in a multi-user environment.

This modification tries to address that by
- showing the internal ID as decimal int as well as base-36 int (great for short part labels)
- adding an internal ID column (hidden by default)
- Adding the internal ID to the filter panel (base-36 ids can be searched by prefixing with a # sign)

Hope you like the modifications and keep up the great work