### PR TITLE
[Bugfix] Divide by zero error when migrating database schema on upgrade install initial setup #650

### DIFF
--- a/src/PartKeepr/PartBundle/Entity/Part.php
+++ b/src/PartKeepr/PartBundle/Entity/Part.php
@@ -844,18 +844,17 @@ class Part extends BaseEntity
             
             $currentStock += $stockLevel->getStockLevel();
             
-            if ($stockLevel->getStockLevel() > 0) {
-                $lastPosEntryQuant = $stockLevel->getStockLevel();
-                $lastPosEntryPrice = $stockLevel->getPrice();
-                $totalPartStockPrice += $lastPosEntryPrice * ($lastPosEntryQuant + $negativeStock);
-                $avgPrice = $totalPartStockPrice / $currentStock;
+            if ($currentStock <= 0) {
+                $avgPrice = 0;
+                $totalPartStockPrice = 0;
+                $negativeStock = $currentStock;
             } else {
-                if ($currentStock <= 0) {
-                    $avgPrice = 0;
-                    $totalPartStockPrice = 0;
-                    $negativeStock = $currentStock;
+                if ($stockLevel->getStockLevel() > 0) {
+                    $lastPosEntryQuant = $stockLevel->getStockLevel();
+                    $lastPosEntryPrice = $stockLevel->getPrice();
+                    $totalPartStockPrice += $lastPosEntryPrice * ($lastPosEntryQuant + $negativeStock);
+                    $avgPrice = $totalPartStockPrice / $currentStock;
                 } else {
-                    $negativeStock = 0;
                     if ($currentStock < $lastPosEntryQuant) {
                         $totalPartStockPrice = $currentStock * $lastPosEntryPrice;
                         $avgPrice = $totalPartStockPrice / $currentStock;
@@ -863,6 +862,7 @@ class Part extends BaseEntity
                         $totalPartStockPrice += $stockLevel->getStockLevel() * $avgPrice;
                         $avgPrice = $totalPartStockPrice / $currentStock;
                     }
+                    $negativeStock = 0;
                 }
             }
 		}


### PR DESCRIPTION
Fixed formatting issue.
Small refactoring for easier debugging.
Corrected issue with stock updates (avgprice) when the sum of additions and removals for a single Part equals 0 and the last entry was an addition