### PR TITLE
Force save on a newly created user preference, fixes #652

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/PartKeepr.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/PartKeepr.js
@@ -367,7 +367,7 @@ Ext.application({
             var j = new PartKeepr.AuthBundle.Entity.UserPreference();
             j.set("preferenceKey", key);
             j.set("preferenceValue", value);
-
+            j.save();
             this.userPreferenceStore.add(j);
         }
     },


### PR DESCRIPTION
Force save on a newly created user preference, fixes #652