### PR TITLE
Fix for #815 and an empty part params dropdown list

### DIFF
--- a/src/PartKeepr/FootprintBundle/Entity/Footprint.php
+++ b/src/PartKeepr/FootprintBundle/Entity/Footprint.php
@@ -226,9 +226,11 @@ class Footprint extends BaseEntity
      *
      * @return void
      */
-    public function removeAttachment(FootprintAttachment $attachment)
+    public function removeAttachment($attachment)
     {
-        $attachment->setFootprint(null);
+        if ($attachment instanceof FootprintAttachment) {
+            $attachment->setFootprint(null);
+        }
         $this->attachments->removeElement($attachment);
     }
 }

--- a/src/PartKeepr/PartBundle/Controller/PartController.php
+++ b/src/PartKeepr/PartBundle/Controller/PartController.php
@@ -107,7 +107,7 @@ class PartController extends FOSRestController
      */
     public function getParameterNamesAction()
     {
-        $dql = "SELECT p.name, p.description, p.valueType, u.name AS unitName, u.symbol AS unitSymbol FROM PartKeepr\PartBundle\Entity\PartParameter p LEFT JOIN p.unit  u GROUP BY p.name, p.description, p.valueType, u.name";
+        $dql = "SELECT p.name, p.description, p.valueType, u.name AS unitName, u.symbol AS unitSymbol FROM PartKeepr\PartBundle\Entity\PartParameter p LEFT JOIN p.unit  u GROUP BY p.name, p.description, p.valueType, u.name, u.symbol";
 
         $query = $this->get("doctrine.orm.default_entity_manager")->createQuery($dql);
 


### PR DESCRIPTION
249f1c9 - simple fix for the #815 footprint attachment issue
19401ec - after upgrading to current git sources (16.02.2017), I've noticed that the part parameters dropdown no longer works - which prevented me from testing the metapart feature. It seems that the u.symbol field is missing in the GROUP BY clause - see query in getParameterNamesAction() (PartController.php). Tested on MySQL 5.7.16.