### PR TITLE
Report.php: Avoid null or empty report names.

### DIFF
--- a/src/PartKeepr/ProjectBundle/Entity/Report.php
+++ b/src/PartKeepr/ProjectBundle/Entity/Report.php
@@ -103,7 +103,7 @@ class Report extends BaseEntity
      */
     public function setName($name)
     {
-        if ($name != NULL) {
+        if ($name != null) {
             $this->name = $name;
         } else {
             $this->name = 'NewReport';

--- a/src/PartKeepr/ProjectBundle/Entity/Report.php
+++ b/src/PartKeepr/ProjectBundle/Entity/Report.php
@@ -103,8 +103,11 @@ class Report extends BaseEntity
      */
     public function setName($name)
     {
-        $this->name = $name;
-
+        if ($name != NULL) {
+            $this->name = $name;
+        } else {
+            $this->name = 'NewReport';
+        }
         return $this;
     }
 

--- a/src/PartKeepr/ProjectBundle/Entity/Report.php
+++ b/src/PartKeepr/ProjectBundle/Entity/Report.php
@@ -106,9 +106,9 @@ class Report extends BaseEntity
         if ($name != null) {
             $this->name = $name;
         } else {
-            $this->name = 'NewReport';
+            $this->name = 'NewReport'; //@todo i18n
         }
-        
+
         return $this;
     }
 

--- a/src/PartKeepr/ProjectBundle/Entity/Report.php
+++ b/src/PartKeepr/ProjectBundle/Entity/Report.php
@@ -108,6 +108,7 @@ class Report extends BaseEntity
         } else {
             $this->name = 'NewReport';
         }
+        
         return $this;
     }
 


### PR DESCRIPTION
If the report name is null or empty, then it doesn't show up.
This patch ensures that all reports have a name immediately on creation,
so they are visible (and can be deleted).