### PR TITLE
Fixes 997: Duplicate expand button changed to collapse button

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartsGrid.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartsGrid.js
@@ -115,11 +115,11 @@ Ext.define('PartKeepr.PartsGrid', {
 
         this.bottomToolbar.add({
             xtype: 'button',
-            tooltip: i18n("Expand all Groups"),
-            iconCls: this.expandRowButtonIconCls,
+            tooltip: i18n("Collapse all Groups"),
+            iconCls: this.collapseRowButtonIconCls,
             listeners: {
                 scope: this.groupingFeature,
-                click: this.groupingFeature.expandAll
+                click: this.groupingFeature.collapseAll
             }
 
         });


### PR DESCRIPTION
Fixes #997 
Rewrote the duplicate code section. Replaced all "expand" with "collapse".