### PR TITLE
Fixing notice warning about a non well formed numeric value

### DIFF
--- a/app/PartKeeprRequirements.php
+++ b/app/PartKeeprRequirements.php
@@ -120,13 +120,13 @@ class PartKeeprRequirements extends SymfonyRequirements
         switch ($last) {
             // The 'G' modifier is available since PHP 5.1.0
             case 'g':
-                $val *= 1073741824;
+                $val = intval($val.substr(0, strlen($val) - 1)) * 1073741824;
                 break;
             case 'm':
-                $val *= 1048576;
+                $val = intval($val.substr(0, strlen($val) - 1)) * 1048576;
                 break;
             case 'k':
-                $val *= 1024;
+                $val = intval($val.substr(0, strlen($val) - 1)) * 1024;
                 break;
         }
 


### PR DESCRIPTION
During the installation process at the Partkeeper requirements checks I got an error (because I have E_ALL set and the notice messed up a response JSON):
```
Invalid Response from server
Notice:  A non well formed numeric value encountered in /var/www/PartKeepr/app/PartKeeprRequirements.php on line 126
....
```
This happened because the memory limit in my PHP ini was set to 256M and in the mentioned line it was multiplied with 1048576 without any casting. The PR adds casting and removes the last character if necessary.