### PR TITLE
Disable the Tip of the day test temporaryly

### DIFF
--- a/src/PartKeepr/TipOfTheDayBundle/Tests/SyncTipsTest.php
+++ b/src/PartKeepr/TipOfTheDayBundle/Tests/SyncTipsTest.php
@@ -21,7 +21,7 @@ class SyncTipsTest extends WebTestCase
 
         //$this->assertGreaterThan(1, $query->getSingleScalarResult());
         $this->markTestSkipped(
-			'Synchronization of the tips of the day (PartKeepr\TipOfTheDayBundle\Tests\SyncTipsTest) skipped'
+            'Synchronization of the tips of the day (PartKeepr\TipOfTheDayBundle\Tests\SyncTipsTest) skipped'
         );
     }
 }

--- a/src/PartKeepr/TipOfTheDayBundle/Tests/SyncTipsTest.php
+++ b/src/PartKeepr/TipOfTheDayBundle/Tests/SyncTipsTest.php
@@ -19,6 +19,9 @@ class SyncTipsTest extends WebTestCase
 
         $query = $this->getContainer()->get('doctrine.orm.entity_manager')->createQuery($dql);
 
-        $this->assertGreaterThan(1, $query->getSingleScalarResult());
+        //$this->assertGreaterThan(1, $query->getSingleScalarResult());
+        $this->markTestSkipped(
+			'Synchronization of the tips of the day (PartKeepr\TipOfTheDayBundle\Tests\SyncTipsTest) skipped'
+        );
     }
 }


### PR DESCRIPTION
As the tip of the day is not working as expected (server does not provide useful information), let's disable it for now. As soon as the service is online again, we can reenable it quickly.