### PR TITLE
Updated Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: Bug
+labels: Bug, needs-triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,6 +38,10 @@ assignees: ''
 ## System Information
 
 * PartKeepr Version:
+* Operating System:
+* Web Server: apache/nginx/...
+* PHP Version:
+* Database and version:
 * Reproducible on the demo system: Yes/No.
 
 ## JavaScript errors

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for a new feature
 title: ''
-labels: Feature Request
+labels: Feature Request, needs-triage
 assignees:
 
 ---

--- a/.github/ISSUE_TEMPLATE/help.md
+++ b/.github/ISSUE_TEMPLATE/help.md
@@ -1,7 +1,7 @@
 ---
 name: Help request
 about: Request help from the developers or ask for another reason
-labels: help-requested
+labels: help-requested, needs-triage
 title: ''
 assignees: ''
 


### PR DESCRIPTION
I just saw that I forgot to ask for some program versions in the bug issue template. Added these.

Also, I added a default label `needs-triage` to all issues. This label most probably must be created before it can be used. This should allow for easier filtering in the future.