### PR TITLE
Added check during setup for Mariadb >= 10.2

### DIFF
--- a/src/PartKeepr/SetupBundle/Controller/SetupController.php
+++ b/src/PartKeepr/SetupBundle/Controller/SetupController.php
@@ -31,11 +31,66 @@ class SetupController extends SetupBaseController
             $response['success'] = false;
             $response['message'] = 'Connection Error';
             $response['errors'] = [$e->getMessage()];
+    /**
+     * @Route("/setup/_int_test_dbversion")
+     */
+    public function intTestDBVersionAction(Request $request)
+    {
+        if (!$this->ensureAuthKey($request)) {
+            return $this->getAuthKeyErrorResponse();
+        }
+
+        $response = [
+            'success' => true,
+            'errors'  => [],
+            'message' => 'Connection successful',
+        ];
+
+        try {
+            $db = $this->get('doctrine.dbal.default_connection');
+            $db->connect();
+        } catch (DriverException $e) {
+            $response['success'] = false;
+            $response['message'] = 'Connection Error';
+            $response['errors'] = [$e->getMessage()];
+            
+            return new JsonResponse($response);
+        }
+        
+        $retArr = $db->fetchArray("SELECT version();");
+        $version = $retArr[0];
+        
+        if(preg_match('/^([0-9]*)\.([0-9]*)\.([0-9]*)-mariadb.*/i', $version, $matches)) {
+            // We are running mariadb. This could cause problems.
+            $major = $matches[1];
+            $minor = $matches[2];
+            if($major == 10 && $minor >= 2) {
+                $response['success'] = false;
+                $response['message'] = 'Incompatible MariaDB version';
+                $response['errors'] = ['Current dependency Symfony is incompatible with MariaDB >= 10.2.'];
+                return new JsonResponse($response);
+            }
         }
 
         return new JsonResponse($response);
     }
 
+    /**
+     * @Route("/setup/testDBVersion")
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function testDBVersionAction(Request $request)
+    {
+        $this->dumpConfig($request);
+        
+        $response = $this->handleRequest($request, '/setup/_int_test_dbversion');
+        
+        return new Response($response->getContent());
+    }
+    
     /**
      * @Route("/setup/testConnectivity")
      *

--- a/src/PartKeepr/SetupBundle/Controller/SetupController.php
+++ b/src/PartKeepr/SetupBundle/Controller/SetupController.php
@@ -58,21 +58,22 @@ class SetupController extends SetupBaseController
             $response['success'] = false;
             $response['message'] = 'Connection Error';
             $response['errors'] = [$e->getMessage()];
-            
+
             return new JsonResponse($response);
         }
-        
+
         $retArr = $db->fetchArray("SELECT version();");
         $version = $retArr[0];
-        
-        if(preg_match('/^([0-9]*)\.([0-9]*)\.([0-9]*)-mariadb.*/i', $version, $matches)) {
+
+        if (preg_match('/^([0-9]*)\.([0-9]*)\.([0-9]*)-mariadb.*/i', $version, $matches)) {
             // We are running mariadb. This could cause problems.
             $major = $matches[1];
             $minor = $matches[2];
-            if($major == 10 && $minor >= 2) {
+            if ($major == 10 && $minor >= 2) {
                 $response['success'] = false;
                 $response['message'] = 'Incompatible MariaDB version';
                 $response['errors'] = ['Current dependency Symfony is incompatible with MariaDB >= 10.2.'];
+
                 return new JsonResponse($response);
             }
         }
@@ -90,12 +91,12 @@ class SetupController extends SetupBaseController
     public function testDBVersionAction(Request $request)
     {
         $this->dumpConfig($request);
-        
+
         $response = $this->handleRequest($request, '/setup/_int_test_dbversion');
-        
+
         return new Response($response->getContent());
     }
-    
+
     /**
      * @Route("/setup/testConnectivity")
      *

--- a/src/PartKeepr/SetupBundle/Controller/SetupController.php
+++ b/src/PartKeepr/SetupBundle/Controller/SetupController.php
@@ -31,6 +31,11 @@ class SetupController extends SetupBaseController
             $response['success'] = false;
             $response['message'] = 'Connection Error';
             $response['errors'] = [$e->getMessage()];
+        }
+
+        return new JsonResponse($response);
+    }
+
     /**
      * @Route("/setup/_int_test_dbversion")
      */

--- a/web/setup/index.html
+++ b/web/setup/index.html
@@ -40,6 +40,7 @@
     <script type="text/javascript" src="js/SetupTests/WebserverRewriteTest.js"></script>
     <script type="text/javascript" src="js/SetupTests/PHPPrerequisitesTest.js"></script>
     <script type="text/javascript" src="js/SetupTests/DatabaseConnectivityTest.js"></script>
+    <script type="text/javascript" src="js/SetupTests/DatabaseVersionTest.js"></script>
     <script type="text/javascript" src="js/SetupTests/PHPSettingsTest.js"></script>
     <script type="text/javascript" src="js/SetupTests/ExistingConfigurationTest.js"></script>
     <script type="text/javascript" src="js/SetupTests/ExistingUserTest.js"></script>

--- a/web/setup/js/Cards/DatabaseSetupCard.js
+++ b/web/setup/js/Cards/DatabaseSetupCard.js
@@ -16,6 +16,7 @@ Ext.define('PartKeeprSetup.DatabaseSetupCard', {
     setupTests: function ()
     {
         this.tests.push(new PartKeeprSetup.DatabaseConnectivityTest());
+        this.tests.push(new PartKeeprSetup.DatabaseVersionTest());
         this.tests.push(new PartKeeprSetup.SchemaSetup());
         this.tests.push(new PartKeeprSetup.SchemaMigration());
         this.tests.push(new PartKeeprSetup.PartUnitSetup());

--- a/web/setup/js/SetupTests/DatabaseVersionTest.js
+++ b/web/setup/js/SetupTests/DatabaseVersionTest.js
@@ -1,0 +1,9 @@
+/**
+ * Tests if the database can be reached
+ */
+Ext.define('PartKeeprSetup.DatabaseVersionTest', {
+    extend: 'PartKeeprSetup.AbstractTest',
+    action: 'testDBVersion',
+    name: "Database",
+    message: "Testing for valid database version",
+});


### PR DESCRIPTION
This PR should in fact avoid issues like #1050 that is a typical problem of a too new MariaDB. This patch will warn the administrator during setup about the issue.