### PR TITLE
Disabled crawling of the main page

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -2,3 +2,5 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
+Disallow: /
+


### PR DESCRIPTION
Currently, there is a `robots.txt` file present but it does nothing. PartKeepr is no page to be visited by unknown users, so it makes sense to forbid the crawling of the page using a robots.txt.
This is a way to disallow in case PartKeepr is installed in the root folder of the current http(s) server.