### PR TITLE
Removed obsolete PHP 5.6 checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 os: linux
 
 php:
-    - 5.6
     - 7.0
+    - 7.1
     - nightly
 
 env:

--- a/web/setup/tests/check-php.php
+++ b/web/setup/tests/check-php.php
@@ -1,9 +1,9 @@
 /**
 <?php
 echo '*/';
-if (version_compare(phpversion(), '5.6.0', '<')) {
-    echo '{"success": false, "message": "PHP Version '.phpversion().' is too old, minimum required version is PHP 5.6.",';
-    echo '"errors": ["Your PHP Version is too old. The minimum required version is 5.6.0. ';
+if (version_compare(phpversion(), '7.1.0', '<')) {
+    echo '{"success": false, "message": "PHP Version '.phpversion().' is too old, minimum required version is PHP 7.1.",';
+    echo '"errors": ["Your PHP Version is too old. The minimum required version is 7.1.0. ';
     echo '<a target=\"_blank\" href=\"https://wiki.partkeepr.org/wiki/KB00003:PHP_Version\">Read more…</a>"]}';
 } else {
     echo '{"success": true, "message": "PHP Version '.phpversion().' found"}';


### PR DESCRIPTION
At the moment PHP 5.x is [end of life](https://www.php.net/supported-versions.php). It does not make sense to test against those old versions. As soon as we have the framework updated, we should even proceed further into more recent php versions as 7.1 is also EOL but the best bet we still have.