### PR TITLE
Implement Features #341 / #404

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Project/ProjectReportResultGrid.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Project/ProjectReportResultGrid.js
@@ -439,7 +439,7 @@ Ext.define("PartKeepr.Components.Project.ProjectReportResultGrid", {
     },
     processCheapestDistributorForProjectPart: function (projectPart)
     {
-        var cheapestDistributor = this.getCheapestDistributor(projectPart.getPart());
+        var cheapestDistributor = this.getCheapestDistributor(projectPart.getPart(), projectPart.get("missing"));
 
         if (cheapestDistributor !== null)
         {
@@ -450,7 +450,7 @@ Ext.define("PartKeepr.Components.Project.ProjectReportResultGrid", {
             projectPart.set("itemSum", projectPart.get("quantity") * projectPart.get("itemPrice"));
         }
     },
-    getCheapestDistributor: function (part)
+    getCheapestDistributor: function (part, partCount)
     {
         var cheapestDistributor = null;
         var currentPrice;
@@ -471,6 +471,11 @@ Ext.define("PartKeepr.Components.Project.ProjectReportResultGrid", {
             }
 
             if (activeDistributor.get("ignoreForReports") === true)
+            {
+                continue;
+            }
+
+            if (activeDistributor.get("packagingUnit") > partCount)
             {
                 continue;
             }


### PR DESCRIPTION
Implements the feature described in issue(s) #341 / #404 (related / duplicates)

This simply adds a check to the report calculation (frontend JavaScript) which takes the packagingUnit into account.

If the part count (so the missing parts which have to be ordered) is not larger than the packagingUnit of the part distributor, that distributor is omitted (by the continue keyword).