### PR TITLE
Allow PHP 7.0 as well in setup scripts

### DIFF
--- a/web/setup/tests/check-php.php
+++ b/web/setup/tests/check-php.php
@@ -1,9 +1,9 @@
 /**
 <?php
 echo '*/';
-if (version_compare(phpversion(), '7.1.0', '<')) {
-    echo '{"success": false, "message": "PHP Version '.phpversion().' is too old, minimum required version is PHP 7.1.",';
-    echo '"errors": ["Your PHP Version is too old. The minimum required version is 7.1.0. ';
+if (version_compare(phpversion(), '7.0.0', '<')) {
+    echo '{"success": false, "message": "PHP Version '.phpversion().' is too old, minimum required version is PHP 7.0.",';
+    echo '"errors": ["Your PHP Version is too old. The minimum required version is 7.0.0. ';
     echo '<a target=\"_blank\" href=\"https://wiki.partkeepr.org/wiki/KB00003:PHP_Version\">Read more…</a>"]}';
 } elseif (version_compare(phpversion(), '7.2', '>=')) {
     echo '{"success": false, "message": "PHP Version '.phpversion().' is not supported.",';


### PR DESCRIPTION
Due to multiple recent requests, it became obvious that multiple distributions (e..g  Debian and Ubuntu) do not have PHP 7.1 in their repositories. The PHP version of 7.0 is still available in some old variants. Thus, I relaxed the requirements restrictions until we have a newer Symfony (with newer PHP support) available.