### PR TITLE
update replaceFromURL's user-agent to avoid TI ban

### DIFF
--- a/src/PartKeepr/UploadedFileBundle/Services/UploadedFileService.php
+++ b/src/PartKeepr/UploadedFileBundle/Services/UploadedFileService.php
@@ -125,8 +125,8 @@ class UploadedFileService extends ContainerAware
         $header[] = 'Accept-Language: en-us,en;q=0.5';
         $header[] = 'Pragma: ';
 
-        $browser = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 ';
-        $browser .= '(KHTML, like Gecko) Version/14.0.1 Safari/605.1.15';
+        $browser = 'Mozilla/5.0 (X11; Linux x86_64; rv:83.0) ';
+        $browser .= 'Gecko/20100101 Firefox/83.0';
 
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_USERAGENT, $browser);

--- a/src/PartKeepr/UploadedFileBundle/Services/UploadedFileService.php
+++ b/src/PartKeepr/UploadedFileBundle/Services/UploadedFileService.php
@@ -125,8 +125,8 @@ class UploadedFileService extends ContainerAware
         $header[] = 'Accept-Language: en-us,en;q=0.5';
         $header[] = 'Pragma: ';
 
-        $browser = 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.3) Gecko/2008092510 ';
-        $browser .= 'Ubuntu/8.04 (hardy) Firefox/3.0.3';
+        $browser = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 ';
+        $browser .= '(KHTML, like Gecko) Version/14.0.1 Safari/605.1.15';
 
         curl_setopt($curl, CURLOPT_URL, $url);
         curl_setopt($curl, CURLOPT_USERAGENT, $browser);


### PR DESCRIPTION
Updates the user-agent used for attachment downloading by url. The old one seems to be blacklisted by TI and causes #1121. This fixes it.