### PR TITLE
gitenv typo and travis test update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: trusty
 os: linux
 
 php:
-    - 7.0
+    #- 7.0
     - 7.1
-    - nightly
+    #- nightly
 
 env:
     - SYMFONY__TESTDB=mysql DB=mysql
@@ -26,7 +26,7 @@ before_script:
   - if [[ "$SYMFONY__TESTDB" == "pgsql" ]]; then psql -c "create database partkeepr_test;" -U postgres; fi
   - if [[ "$SYMFONY__TESTDB" == "mysql" ]]; then mysql -e "DROP database IF EXISTS partkeepr_test;" -uroot; fi
   - if [[ "$SYMFONY__TESTDB" == "mysql" ]]; then mysql -e "create database IF NOT EXISTS partkeepr_test;" -uroot; fi
-  - composer self-update
+  - composer self-update --1 #limit to composer v1
   - composer install --prefer-source --no-interaction
   - app/console cache:warmup --env=test
   - app/console doctrine:schema:create --env=test

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,9 +47,9 @@ In order to start using the suggested development environment a few steps are re
 This guide assumes, you have just freshly checked out the PartKeer repository from git.
 
 - Navigate in a console to the folder `docker/development`.
-- Copy the file `.github.env.dist` to `.github.env`.
-- Create a github personal access token in the settings on github. You need no additional rights. Put the generated token into the file `.github.env` where the `XXX...XXX` markers are.
-    - Alternatively, you can also remove the line in the `.github.env` file. The reason for this setup is that github poses a rate limit on the number of accesses. When using the `composer` command much, these rate limits might be triggered easily. By logging in, the limits are pushed to higher values.
+- Copy the file `github.env.dist` to `github.env`.
+- Create a github personal access token in the settings on github. You need no additional rights. Put the generated token into the file `github.env` where the `XXX...XXX` markers are.
+    - Alternatively, you can also remove the line in the `github.env` file. The reason for this setup is that github poses a rate limit on the number of accesses. When using the `composer` command much, these rate limits might be triggered easily. By logging in, the limits are pushed to higher values.
 
 - Call `docker-compose pull` to fetch all images from the docker hub. Alternatively you could [build the images manually](#building-the-images-manually).
 - Now you need to fire up the database and let it initialize. This is done by callng `docker-compose up -d db`. You can peek into the process by `docker-compose logs -f db`. Wait for a message that the server is ready for connections and listening on port 3306. Using `<Ctrl><c>`, you can exit from the logs.


### PR DESCRIPTION
fixed PR  #1166.
Typo in docker dev readme
minor updates to .travis.yml so it works as a sanity check until migration to github actions is complete.