### PR TITLE
don't autosearch octo for empty name

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/Editor/PartEditorWindow.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/Editor/PartEditorWindow.js
@@ -140,7 +140,9 @@ Ext.define('PartKeepr.PartEditorWindow', {
             this.octoPartQueryWindow = Ext.create("PartKeepr.Components.OctoPart.SearchWindow");
             this.octoPartQueryWindow.show();
             this.octoPartQueryWindow.setPart(this.editor.record);
-            this.octoPartQueryWindow.startSearch(this.editor.nameField.getValue());
+            let name = this.editor.nameField.getValue();
+            if (name !== "")
+                this.octoPartQueryWindow.startSearch(name);
             this.octoPartQueryWindow.on("refreshData", this.onRefreshData, this);
         } else {
             Ext.MessageBox.alert(i18n("Octopart is not configured"), i18n("Your administrator needs to configure the API key for Octopart in the parameters.php file - see parameters.php.dist for instructions"));


### PR DESCRIPTION
TL;DR: Save OctoPart API credits by not auto-searching for empty names.

Currently, when the "Octopart..." button is pressed in the "Add Part" window, an automatic query is performed with the value of the "Name" field. This happens even if the user haven't inputted anything into the "Name" field yet, most likely with the intention of doing it in the "Octopart Search" window itself. This effectively wastes the `partkeepr.octopart.limit` number of credits on running an effectively useless query. Changes in this PR prevent auto-running empty queries (but do not prevent one from manually running them from the "Octopart Search" window itself by pressing "Enter" in case one might for some weird reason desire to).