### PR TITLE
fix missing parameter in setup procedure

### DIFF
--- a/src/PartKeepr/SetupBundle/Services/ConfigSetupService.php
+++ b/src/PartKeepr/SetupBundle/Services/ConfigSetupService.php
@@ -85,6 +85,7 @@ class ConfigSetupService
             'partkeepr.users.limit'                    => false,
             'partkeepr.parts.internalpartnumberunique' => false,
             'partkeepr.octopart.apikey'                => "",
+            'partkeepr.octopart.limit'                 => "3",
         ];
 
         if (function_exists('apc_fetch')) {


### PR DESCRIPTION
A new installation of PartKeepr fails with this missing parameter.