### PR TITLE
Allow modifying timeouts in setup requests

### DIFF
--- a/web/setup/js/SetupSteps/WarmupCacheSetup.js
+++ b/web/setup/js/SetupSteps/WarmupCacheSetup.js
@@ -6,4 +6,5 @@ Ext.define('PartKeeprSetup.WarmupCacheSetup', {
     action: 'warmupCache',
     name: "Config File",
     message: "Warming up the cache",
+    timeout: 240000
 });

--- a/web/setup/js/SetupTests/AbstractTest.js
+++ b/web/setup/js/SetupTests/AbstractTest.js
@@ -55,6 +55,11 @@ Ext.define('PartKeeprSetup.AbstractTest', {
      *
      */
     params: {},
+	
+    /**
+     * Request timeout, in milliseconds.
+     */
+    timeout: 120000,
 
     /**
      * Constructs the test
@@ -93,7 +98,7 @@ Ext.define('PartKeeprSetup.AbstractTest', {
             method: this.method,
             scope: this,
             params: Ext.encode(this.params),
-            timeout: 120000
+            timeout: this.timeout
         });
     },
 


### PR DESCRIPTION
Would fix https://github.com/partkeepr/PartKeepr/issues/811 when cache warmup takes too long. Probably, since I don't know JS