### PR TITLE
Frontend fixes for #1113

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartStockWindow.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartStockWindow.js
@@ -161,11 +161,32 @@ Ext.define('PartKeepr.PartStockWindow', {
                 price = this.priceField.getValue() / this.quantityField.getValue();
             }
 
-            Ext.callback(this.callbackFn,
+            //Warn the user if they want to remove more than the current available 
+            var current_stock = this.callbackScope.record.data.stockLevel;
+            if ((this.title  ==   this.removePartText) & (this.quantityField.getValue() > current_stock)){
+
+                    Ext.Msg.confirm(i18n("Not enough stock"), 
+                                    i18n("You are removing more parts than are in stock. \
+                                          If you continue a negative stock will be tracked. <br><br> \
+                                          Are you sure you want to remove these parts?"),
+                        function(buttonid){
+                            // if yes, submit data as normal
+                            if (buttonid == "yes") {
+                                Ext.callback(this.callbackFn,
+                                this.callbackScope,
+                                [this.quantityField.getValue(), price, this.commentField.getValue()]);
+                                this.close();
+                            }
+                            return; //otherwise, return without doing anything
+                        }, this);
+            }
+            else {  // add or remove stock normally
+                Ext.callback(this.callbackFn,
                 this.callbackScope,
                 [this.quantityField.getValue(), price, this.commentField.getValue()]);
-            this.close();
-        }
+                this.close();
+            }
+        }   
     },
     /**
      * Opens the window in "add stock" mode. The target callback receives three parameters: the value of the quantity

--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartStockWindow.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/Part/PartStockWindow.js
@@ -201,7 +201,6 @@ Ext.define('PartKeepr.PartStockWindow', {
         this.priceField.hide();
         this.priceCheckbox.hide();
         this.okButton.setIconCls("web-icon brick_delete");
-        this.quantityField.maxValue = this.callbackScope.record.data.stockLevel;
         this.show();
     }
 });


### PR DESCRIPTION
Frontend fixes for issue #1113:

- Revert previous merge on this issue which prevented negative stock levels
- Add a warning/confirmation dialog before allowing the user to create negative stock levels

Per discussions on the bug tracker negative stock levels are an intended feature covering a common use case, so this should close the issue. 

Happy to hear suggestions for improvements to the warning text.

Tested via Chrome devtools but I could not get the docker dev image working to build and test.

![UserWarningMessage](https://user-images.githubusercontent.com/40479137/110728909-cb1e7280-81eb-11eb-9a2f-f752ee8d5b2e.PNG)
