### PR TITLE
Show errors from Octopart search 

### DIFF
--- a/src/PartKeepr/FrontendBundle/Resources/public/js/Components/OctoPart/SearchPanel.js
+++ b/src/PartKeepr/FrontendBundle/Resources/public/js/Components/OctoPart/SearchPanel.js
@@ -206,7 +206,7 @@ Ext.define("PartKeepr.Components.OctoPart.SearchPanel", {
     },
     checkForErrors: function (data)
     {
-        if (data.results.length == 0 && data.errors && data.errors.length > 0) {
+        if (data.errors && data.errors.length > 0) {
             Ext.Msg.alert(i18n("Octopart Error"), data.errors.map(e => e.message).join());
         }
 

--- a/src/PartKeepr/OctoPartBundle/Services/OctoPartService.php
+++ b/src/PartKeepr/OctoPartBundle/Services/OctoPartService.php
@@ -55,9 +55,6 @@ class OctoPartService
                 credit_string
                 text
               }
-              cad {
-                add_to_library_url
-              }
               reference_designs {
                   name
                   url
@@ -136,9 +133,6 @@ EOD;
                     descriptions {
                       credit_string
                       text
-                    }
-                    cad {
-                      add_to_library_url
                     }
                     reference_designs {
                         name


### PR DESCRIPTION
Currently errors are only shown if no results are returned, but Octopart returns results (empty ones).
This "fixes" #1178 and #1203, because now the error message mentions the user should upgrade to the PRO account (which is free).
Even the PRO account cannot retrieve cad data. Disabled.