### PR TITLE
Fix Docker build and add jpeg support

### DIFF
--- a/docker/base-dev/Dockerfile
+++ b/docker/base-dev/Dockerfile
@@ -3,13 +3,13 @@ FROM php:7.1-apache-buster
 
 RUN apt-get update && \
 	apt-get upgrade -y && \
-	apt-get install -y sudo curl wget git unzip libldap2-dev libpng++-dev libicu-dev libcurl4-gnutls-dev libxml2-dev libpq-dev libfreetype6-dev nano less vim && \
+	apt-get install -y sudo curl wget git unzip libldap2-dev libjpeg62-turbo-dev libpng++-dev libicu-dev libcurl4-gnutls-dev libxml2-dev libpq-dev libfreetype6-dev nano less vim && \
 	apt-get clean && \
 	docker-php-ext-configure ldap && docker-php-ext-install ldap && \
 	docker-php-ext-configure bcmath && docker-php-ext-install bcmath && \
-	docker-php-ext-configure gd --with-freetype-dir=/usr/include/freetype2 && docker-php-ext-install gd && \
+	docker-php-ext-configure gd --with-freetype-dir=/usr/include/freetype2 --with-jpeg-dir && docker-php-ext-install gd && \
 	docker-php-ext-install opcache intl dom pdo pdo_mysql pdo_pgsql && \
-	pecl install xdebug && docker-php-ext-enable xdebug && \
+	pecl install xdebug-2.9.0 && docker-php-ext-enable xdebug && \
 	pecl install apcu_bc-beta && \
 	docker-php-ext-enable apcu apc && \
 	mv /usr/local/etc/php/conf.d/docker-php-ext-apcu.ini /usr/local/etc/php/conf.d/10-docker-php-ext-apcu.ini && \


### PR DESCRIPTION
The Docker build was failing because xdebug required a newer version of php. 
Also added a missing lib for jpeg support. Uploading a jpeg would otherwise result in thumbnails displaying '500 Server Error'.